### PR TITLE
[Lint] Add `max-doc-length` linter and enable the automatically fix by ruff.

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -8,6 +8,7 @@ fi
 
 if ! command -v ruff &> /dev/null
 then
+    # https://docs.astral.sh/ruff/tutorial/
     echo "ruff could not be found"
     echo "Please install ruff by running 'pip install ruff'"
     exit
@@ -16,11 +17,12 @@ fi
 # Check if arguments are provided.
 if [ "$#" -eq 0 ]
 then
+    # Lint all files in the current directory, and fix any fixable errors.
     echo "Lint all files"
     ufmt format llama/
-    ruff check llama/
+    ruff check llama/ --fix
 else
     echo "Lint specific files"
     ufmt format "$@"
-    ruff check "$@"
+    ruff check "$@" --fix
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,11 @@ line-length = 80
 profile = "black"
 
 [tool.ruff.lint]
-select = ["D"]
+select = ["D", "W505"]
 ignore = ["D100", "D102", "D104", "D105", "D107", "D203", "D213", "D401", "D402"]
+
+[tool.ruff.lint.pycodestyle]
+max-doc-length = 100
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

- [x] Add `max-doc-length` linter.
- [x] Enable the automatically fix by ruff.

Some valuable archives are as follows:
- [Ruff: `lint.pycodestyle.max-doc-length`](https://docs.astral.sh/ruff/settings/#lint_pycodestyle_max-doc-length)
- [Ruff: doc-line-too-long (W505)](https://docs.astral.sh/ruff/rules/doc-line-too-long/)

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the `lint.sh` to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] Code is well-documented.
- [ ] Related issue is referred in this PR.

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
