### PR TITLE
[Lint] Use the linter to format the dual version (EN/CN) of `generation` code.

### DIFF
--- a/llama/generation_cn_comment.py
+++ b/llama/generation_cn_comment.py
@@ -76,7 +76,7 @@ class Llama:
             max_batch_size (int): Maximum batch size for inference.
             model_parallel_size (Optional[int], optional): Number of model parallel processes.
                 If not provided, it's determined from the environment. Defaults to None.
-            seed (int, optional): Random seed for reproducibility. Defaults to 1.
+            seed (int, optional): Random seed for  reproducibility. Defaults to 1.
 
         Returns:
             Llama: An instance of the Llama class with the loaded model and tokenizer.
@@ -100,7 +100,7 @@ class Llama:
         local_rank = int(os.environ.get("LOCAL_RANK", 0))
         torch.cuda.set_device(local_rank)
 
-        # `seed` must be the same in all processes.
+        # seed must be the same in all processes
         torch.manual_seed(seed)
 
         if local_rank > 0:


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->

- [x] Use the linter to format the dual version (EN/CN) of `generation` code.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] I've leverage the `lint.sh` to beautify the python and c++ code.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] Code is well-documented.
- [ ] Related issue is referred in this PR.

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
